### PR TITLE
Use sync.OnceValues to load config once and only once

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -13,9 +13,9 @@ import (
 	"github.com/FollowTheProcess/msg"
 )
 
-// New loads config and returns a new App, it is safe to be called multiple times
+// onceNew loads config and returns a new App, it is safe to be called multiple times
 // and concurrently and will only execute once.
-var New = sync.OnceValues(newApp)
+var onceNew = sync.OnceValues(newApp)
 
 // App represents the dev program.
 type App struct {
@@ -28,6 +28,11 @@ type App struct {
 // Config returns the set config.
 func (a App) Config() config.Config {
 	return a.cfg
+}
+
+// New loads and returns a new App.
+func New() (App, error) {
+	return onceNew()
 }
 
 // newApp builds and returns a new app.

--- a/app/app.go
+++ b/app/app.go
@@ -1,0 +1,72 @@
+// Package app implements the functionality behind the CLI and allows us to execute it
+// in tests without having to feed arguments in.
+package app
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/FollowTheProcess/dev/config"
+	"github.com/FollowTheProcess/msg"
+)
+
+// New loads config and returns a new App, it is safe to be called multiple times
+// and concurrently and will only execute once.
+var New = sync.OnceValues(newApp)
+
+// App represents the dev program.
+type App struct {
+	stdout io.Writer
+	stderr io.Writer
+	cfg    config.Config
+	cfgOk  bool
+}
+
+// Config returns the set config.
+func (a App) Config() config.Config {
+	return a.cfg
+}
+
+// newApp builds and returns a new app.
+func newApp() (App, error) {
+	fmt.Println("app.New() called") // So I can feel warm and fuzzy that it only runs once
+	app := App{
+		stdout: os.Stdout,
+		stderr: os.Stderr,
+		cfgOk:  false,
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return App{}, fmt.Errorf("could not get user home dir: %w", err)
+	}
+	cfgFile := filepath.Join(home, ".dev.toml")
+
+	file, err := os.Open(cfgFile)
+	if err != nil {
+		// Here everything is fine apart from the config file which isn't a dealbreaker for
+		// starting the app, so we allow it
+		// TODO: Use a sensible default?
+		msg.Fwarn(app.stdout, "Config file %s missing or cannot be read: %v", cfgFile, err)
+		return app, nil
+	}
+	defer file.Close()
+
+	cfg, err := config.Load(file)
+	if err != nil {
+		// Here everything is fine apart from the config file which isn't a dealbreaker for
+		// starting the app, so we allow it
+		// TODO: Use a sensible default?
+		msg.Fwarn(app.stdout, "Config file %s cannot be read: %v", cfgFile, err)
+		return app, nil
+	}
+
+	// By now we have loaded the config and everything is fine
+	app.cfg = cfg
+	app.cfgOk = true
+
+	return app, nil
+}

--- a/app/app.go
+++ b/app/app.go
@@ -13,8 +13,7 @@ import (
 	"github.com/FollowTheProcess/msg"
 )
 
-// onceNew loads config and returns a new App, it is safe to be called multiple times
-// and concurrently and will only execute once.
+// onceNew synchronises the call to app.New, ensuring we only ever set it up once.
 var onceNew = sync.OnceValues(newApp)
 
 // App represents the dev program.
@@ -30,7 +29,14 @@ func (a App) Config() config.Config {
 	return a.cfg
 }
 
-// New loads and returns a new App.
+// New builds and returns a new App.
+//
+// It is safe to call multiple times and concurrently as under the hood
+// it is synchronised by sync.Once, ensuring that the app is only ever constructed
+// once, including reading and parsing the config file.
+//
+// It should be called during building of every dev command and subcommand so each has
+// access to the global state.
 func New() (App, error) {
 	return onceNew()
 }

--- a/cli/config/get.go
+++ b/cli/config/get.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 
+	"github.com/FollowTheProcess/dev/app"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +18,7 @@ var getAllowedArgs = []string{
 
 // buildGetmd builds and returns the config get subcommand.
 func buildGetCmd() *cobra.Command {
+	app, err := app.New()
 	cmd := &cobra.Command{
 		Use:       "get KEY",
 		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
@@ -24,7 +26,11 @@ func buildGetCmd() *cobra.Command {
 		Example:   "$ dev config get github.username",
 		ValidArgs: getAllowedArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err != nil {
+				return err
+			}
 			fmt.Printf("config get called with key: %v\n", args[0])
+			fmt.Printf("%+v\n", app.Config())
 			return nil
 		},
 	}

--- a/cli/config/show.go
+++ b/cli/config/show.go
@@ -3,18 +3,24 @@ package config
 import (
 	"fmt"
 
+	"github.com/FollowTheProcess/dev/app"
 	"github.com/spf13/cobra"
 )
 
 // buildShowCmd builds and returns the config show subcommand.
 func buildShowCmd() *cobra.Command {
+	app, err := app.New()
 	cmd := &cobra.Command{
 		Use:     "show",
 		Args:    cobra.NoArgs,
 		Short:   "Display the current config.",
 		Example: "$ dev config show",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err != nil {
+				return err
+			}
 			fmt.Println("config show called")
+			fmt.Printf("%+v\n", app.Config())
 			return nil
 		},
 	}


### PR DESCRIPTION
- Use sync.OnceValues to load config once
- Refactor to avoid global variable
- Improve docs

<!-- Provide a brief summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation if needed.
- [ ] I have updated the tests if needed.
